### PR TITLE
Add Cloudsmith (a VagrantCloud-compatible service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A curated list of awesome Vagrant resources, plugins, tutorials and other nice t
 * [Cloud Images Ubuntu.com](https://cloud-images.ubuntu.com/vagrant/) - "clean" official Ubuntu cloud images.
 * [Baseboxes from Opscode](https://github.com/chef/bento#current-baseboxes) - CentOS, Fedora, Debian, FreeBSD, Ubuntu.
 * [Puppet Labs Vagrant Boxes](http://puppet-vagrant-boxes.puppetlabs.com/) - these boxes are provided to be used by various Puppet projects.
-
+* [Cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with support for Vagrant repositories (and many others).
 
 ## Provisioning
 


### PR DESCRIPTION
This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for hosting Vagrant box repositories (and many other package formats, such as Python/Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc.